### PR TITLE
check error for clGetDeviceIDs

### DIFF
--- a/eradicate2.cpp
+++ b/eradicate2.cpp
@@ -47,7 +47,9 @@ std::vector<cl_device_id> getAllDevices(cl_device_type deviceType = CL_DEVICE_TY
 		clGetDeviceIDs(*it, deviceType, 0, NULL, &countDevice);
 
 		std::vector<cl_device_id> deviceIds(countDevice);
-		clGetDeviceIDs(*it, deviceType, countDevice, deviceIds.data(), &countDevice);
+		if (clGetDeviceIDs(*it, deviceType, countDevice, deviceIds.data(), &countDevice) != CL_SUCCESS) {
+			continue;
+		}
 
 		std::copy( deviceIds.begin(), deviceIds.end(), std::back_inserter(vDevices) );
 	}
@@ -297,7 +299,7 @@ int main(int argc, char * * argv) {
 			const auto globalMemSize = clGetWrapper<cl_ulong>(clGetDeviceInfo, deviceId, CL_DEVICE_GLOBAL_MEM_SIZE);
 
 			std::cout << "  GPU" << i << ": " << strName << ", " << globalMemSize << " bytes available, " << computeUnits << " compute units" << std::endl;
-			vDevices.push_back(vFoundDevices[i]);
+			vDevices.push_back(deviceId);
 			mDeviceIndex[vFoundDevices[i]] = i;
 		}
 


### PR DESCRIPTION
Reviewer @k06a 
#### Context
I was getting this error:
```
Devices:
  GPU0: AMD Radeon RX 580 Series (radeonsi, polaris10, LLVM 18.1.8, DRM 3.59, 6.11.5-arch1-1), 8589934592 bytes available, 36 compute units
  GPU1: �Q=��`, 6 bytes available, 36 compute units
Initializing OpenCL...
  Creating context...-33
```
`-33` is `CL_INVALID_DEVICE`.
I hunted down the origin of the corruption and determined it was an unhandled error.
#### Changes
* Check the return value of clGetDeviceIDs